### PR TITLE
Fix cookbook name in .kitchen.yml

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,7 +32,7 @@ suites:
   #------------------------------------------------------------ suite[postfix]
   - name: postfix
     run_list:
-      - 'recipe[postfix.rpm::default]'
+      - 'recipe[postfix_rpm::default]'
     attributes:
       postfix:
         version: '2.11.1'


### PR DESCRIPTION
- apparently global search/replace does not include . files...?

[skip ci]
